### PR TITLE
Drop prototype trickery from `testable-clock`

### DIFF
--- a/lib/testable-clock.js
+++ b/lib/testable-clock.js
@@ -35,12 +35,6 @@ function TestableClock (time) {
 		invalidTime();
 	}
 
-	if (typeof Object.setPrototypeOf === 'function') {
-		Object.setPrototypeOf(getTime, TestableClock.prototype);
-	} else {
-		getTime.__proto__ = TestableClock.prototype; // eslint-disable-line no-proto
-	}
-
 	getTime.setTime = function (newTime) {
 		validateTime(newTime);
 		time = newTime;

--- a/test/testable-clock.spec.js
+++ b/test/testable-clock.spec.js
@@ -8,10 +8,6 @@ var assert = require('assert');
 var TestableClock = require('../lib/testable-clock.js');
 
 describe('testable-clock', function () {
-	it('passes instanceOf test', function () {
-		assert(new TestableClock() instanceof TestableClock);
-	});
-
 	it('is a function', function () {
 		assert.strictEqual(typeof new TestableClock(), 'function');
 	});


### PR DESCRIPTION
I thought this was going to be necessary when I first started implementing this.
I was wrong. Its unnecessary, ugly, and confusing.