### PR TITLE
use debug module instead of hand-rolled logging solution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,16 @@ FirebaseServer instances have the following API:
 
 ### Debug logging
 
-You can enable debug logging by calling the `enableLogging()` method:
+This project uses the excellent [`debug`](https://www.npmjs.com/package/debug) module for logging.
+It is configured by setting an environment variable:
 
-```js
-var FirebaseServer = require('firebase-server');
-
-FirebaseServer.enableLogging(true);
-// Create a FirebaseServer instance, etc.
+```sh
+$ DEBUG=* mocha                                # log everything
+$ DEBUG=firebase-server* mocha                 # log everything from firebase-server
+$ DEBUG=firebase-server:token-generator mocha  # log output from specific submodule
 ```
+
+Advanced options are available from the [`debug docs`](https://www.npmjs.com/package/debug)
 
 License
 ----

--- a/index.js
+++ b/index.js
@@ -15,14 +15,7 @@ var TestableClock = require('./lib/testable-clock');
 var TokenValidator = require('./lib/token-validator');
 var Promise = require('native-or-bluebird');
 var firebaseCopy = require('firebase-copy');
-
-var loggingEnabled = false;
-
-function _log(message) {
-	if (loggingEnabled) {
-		console.log('[firebase-server] ' + message); // eslint-disable-line no-console
-	}
-}
+var _log = require('debug')('firebase-server');
 
 function getSnap(ref) {
 	return new Promise(function (resolve) {
@@ -319,10 +312,6 @@ FirebaseServer.prototype = {
 	setSecret: function (newSecret) {
 		this._tokenValidator.setSecret(newSecret);
 	}
-};
-
-FirebaseServer.enableLogging = function (value) {
-	loggingEnabled = value;
 };
 
 module.exports = FirebaseServer;

--- a/lib/token-validator.js
+++ b/lib/token-validator.js
@@ -6,6 +6,7 @@
 
 var jwt = require('jwt-simple');
 var TestableClock = require('./testable-clock');
+var debug = require('debug')('firebase-server:token-validator');
 
 function Generator (secret, time) {
 	if (!time && typeof secret !== 'string') {
@@ -29,6 +30,7 @@ function Generator (secret, time) {
 		if (!noVerify && !isValidTimestamp(decoded)) {
 			throw new Error('invalid timestamp');
 		}
+		debug('decode(token: %j, secret: %j) => %j', token, secret, decoded);
 		return decoded;
 	}
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "proxyquire": "^1.7.3"
   },
   "dependencies": {
+    "debug": "^2.2.0",
     "firebase-copy": "0.2.0",
     "jwt-simple": "^0.3.1",
     "lodash": "3.10.1",


### PR DESCRIPTION
It has a simple API, but configured with an environment variable
instead of a method call.

This will become important as we start splitting up index.js