### PR TITLE
Support admin authentication with raw secret

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,6 +233,10 @@ FirebaseServer.prototype = {
 		}
 
 		function handleAuth(requestId, credential) {
+			if (server._authSecret === credential) {
+				return send({t: 'd', d: {r: requestId, b: {s: 'ok', d: TokenValidator.normalize({ auth: null, admin: true, exp: null }) }}});
+			}
+
 			try {
 				var decoded = server._tokenValidator.decode(credential);
 				authToken = credential;
@@ -310,6 +314,7 @@ FirebaseServer.prototype = {
 	},
 
 	setAuthSecret: function (newSecret) {
+		this._authSecret = newSecret;
 		this._tokenValidator.setSecret(newSecret);
 	}
 };

--- a/test/server.spec.js
+++ b/test/server.spec.js
@@ -557,4 +557,32 @@ describe('Firebase Server', function () {
 			});
 		});
 	});
+
+	describe('FirebaseServer.setAuthSecret()', function () {
+		it('should accept raw secret when handling admin authentication', function (done) {
+			server = new FirebaseServer(PORT);
+			server.setAuthSecret('test-secret');
+			var client = new Firebase(newServerUrl());
+			client.authWithCustomToken('test-secret', function (err, data) {
+				assert.ok(!err, 'authWithCustomToken() call returned an error');
+				assert.equal(data.auth, null);
+				assert.equal(data.uid, null);
+				assert.equal(data.expires, null);
+
+				done();
+			});
+		});
+
+		it('should reject invalid auth requests with raw secret', function (done) {
+			server = new FirebaseServer(PORT);
+			server.setAuthSecret('test-secret');
+			var client = new Firebase(newServerUrl());
+			client.authWithCustomToken('invalid-secret', function (err, data) {
+				assert.ok(err, 'authWithCustomToken() should have failed');
+				assert.ok(err instanceof Error);
+
+				done();
+			});
+		});
+	});
 });


### PR DESCRIPTION
Real servers allow admins to authenticate with just raw secret, without generating a JWT. This PR allows such authentication mechanism.

it actually makes testing much easier as you do not need to generate JWT tokens when trying to log in. On production, I use this mainly because this kind of authentication does not have an expiration.