### PR TITLE
update firebase version to 3.6.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,11 +68,7 @@ function FirebaseServer(port, name, data) {
 	// We must pass a "valid looking" configuration to initializeApp for its
 	// internal checks to pass.
 	var config = {
-		databaseURL: 'ws://fakeserver.firebaseio.test',
-		serviceAccount: {
-			'private_key': 'fake',
-			'client_email': 'fake'
-		}
+		databaseURL: 'ws://fakeserver.firebaseio.test'
 	};
 	this.app = firebase.initializeApp(config, appName);
 	this.app.database().goOffline();

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "coveralls": "2.11.4",
     "eslint": "1.7.3",
     "faye-websocket": "0.10.0",
-    "firebase": "3.3.0",
+    "firebase": "3.6.0",
     "firebase-token-generator": "^2.0.0",
     "istanbul": "0.4.0",
     "mocha": "2.3.3",


### PR DESCRIPTION
fixed the following warninng.

```
The 'serviceAccount' property specified in the first argument to initializeApp()
is deprecated and will be removed in the next major version.
You should instead use the 'firebase-admin' package.
See https://firebase.google.com/docs/admin/setup for details on how to get started.
```

https://firebase.google.com/docs/admin/setup

ref #67