### PR TITLE
Fix compatibility with Android client (path)

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,11 @@ function normalizePath(fullPath) {
 	if (isPriorityPath) {
 		path = path.replace(/\/?\.priority$/, '');
 	}
+	if (path.charAt(0) === '/') {
+		// Normally, a path would start with a slash ("/"), but some clients
+		// (notably Android) don't always send it.
+		path = path.substr(1);
+	}
 	return {
 		isPriorityPath: isPriorityPath,
 		path: path,
@@ -299,7 +304,7 @@ FirebaseServer.prototype = {
 			if (parsed && parsed.t === 'd') {
 				var path;
 				if (typeof parsed.d.b.p !== 'undefined') {
-					path = parsed.d.b.p.substr(1);
+					path = parsed.d.b.p;
 				}
 				path = normalizePath(path || '');
 				var requestId = parsed.d.r;

--- a/index.js
+++ b/index.js
@@ -270,9 +270,9 @@ FirebaseServer.prototype = {
 			try {
 				var decoded = server._tokenValidator.decode(credential);
 				authToken = credential;
-				send({t: 'd', d: {r: requestId, b: {s: 'ok', d: TokenValidator.normalize(decoded)}}});
+				return send({t: 'd', d: {r: requestId, b: {s: 'ok', d: TokenValidator.normalize(decoded)}}});
 			} catch (e) {
-				send({t: 'd', d: {r: requestId, b: {s: 'invalid_token', d: 'Could not parse auth token.'}}});
+				return send({t: 'd', d: {r: requestId, b: {s: 'invalid_token', d: 'Could not parse auth token.'}}});
 			}
 		}
 


### PR DESCRIPTION
For some reason Android client doesn't always send a slash ("/")
as the first character of the path (d.b.p).
This results in crippled paths which listeners don't work for.

Add a check for "/" being the first character of the path.