### PR TITLE
Fix dropped listener callbacks for null nodes

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,9 +181,7 @@ FirebaseServer.prototype = {
 				.then(function () {
 					var sendOk = true;
 					fbRef.on('value', function (snap) {
-						if (snap.exportVal()) {
-							pushData(path, snap.exportVal());
-						}
+						pushData(path, snap.exportVal());
 						if (sendOk) {
 							sendOk = false;
 							send({d: {r: requestId, b: {s: 'ok', d: {}}}, t: 'd'});
@@ -256,7 +254,6 @@ FirebaseServer.prototype = {
 			progress.then(function () {
 				fbRef.set(newData);
 				fbRef.once('value', function (snap) {
-					pushData(path, snap.exportVal());
 					send({d: {r: requestId, b: {s: 'ok', d: {}}}, t: 'd'});
 				});
 			}).catch(_log);


### PR DESCRIPTION
Howdy!
firebase-server has been a great help for me, thanks! I found that it's not notifying listeners when the watched value is being removed. I got the appropriate #remove test to repro the bug, but it required two client connections and some heavy synchronization to make it fail reliably. The dropped pushData on line 259 is just an optimization. I believe it to be unnecessary, since it's just echoing back to the client that sent the change in the first place. Removing it didn't affect the tests.

After the fix was done, I found that the tests would occasionally race against each other (test N client would call into server N-1). I'm not sure why, but I changed it so that every test uses a unique server port, so that if it happens again, it will fail it a much clearer way.

This is my first submission back to a public project, so apologies if I've done anything wrong. I'm happy to clean up my fixes however you'd like.

Cheers, Bri