### PR TITLE
Update targaryen to 2.3.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "firebase": "3.6.1",
     "jwt-simple": "0.3.1",
     "lodash": "3.10.1",
-    "targaryen": "2.0.0",
+    "targaryen": "2.3.3",
     "ws": "1.1.1"
   }
 }


### PR DESCRIPTION
This fixes a few bugs in the rules engine. After 2.3.3, targaryen switches to 3.0.x. I don't have time to do the port to the new rules API at this point, but this seems like a worthwhile update. All tests still pass.

This fixes issue #48.