### PR TITLE
Properly fill in auth object for Android

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,14 +112,15 @@ FirebaseServer.prototype = {
 		function authData() {
 			var data;
 			if (authToken) {
-				var decodedToken;
 				try {
-					decodedToken = server._tokenValidator.decode(authToken);
+					var decodedToken = server._tokenValidator.decode(authToken);
 					if ('d' in decodedToken) {
 						data = decodedToken.d;
 					} else {
 						data = {
-							uid: decodedToken.sub,
+							// 'user_id' is firebase-specific and may be
+							// convenience only; 'sub' is standard JWT.
+							uid: decodedToken.user_id || decodedToken.sub,
 							provider: decodedToken.provider_id,
 							token: decodedToken,
 						};

--- a/index.js
+++ b/index.js
@@ -112,8 +112,18 @@ FirebaseServer.prototype = {
 		function authData() {
 			var data;
 			if (authToken) {
+				var decodedToken;
 				try {
-					data = server._tokenValidator.decode(authToken).d;
+					decodedToken = server._tokenValidator.decode(authToken);
+					if ('d' in decodedToken) {
+						data = decodedToken.d;
+					} else {
+						data = {
+							uid: decodedToken.sub,
+							provider: decodedToken.provider_id,
+							token: decodedToken,
+						};
+					}
 				} catch (e) {
 					authToken = null;
 				}


### PR DESCRIPTION
The "auth" object is later used to do permission checks by the means of targaryen library [1].
I don't know the semantics of the token that JavaScript client sends, but [3] is for what Android sends in, and, given that JavaScript clients were tested to work correctly, I assume the format is different for some reason. The idea of this pull request is to bring the Android token in line with the official documentation at [2].

Why not make this change to targaryen library instead?
Well, the "auth" object supplied to targaryen is supposed to be of the format described in [2] rather than being protocol-bound, so firebase-server, as a protocol handler, is a more appropriate place to put an adapter in.

Fixes #88.

[1] https://github.com/goldibex/targaryen
[2] https://firebase.google.com/docs/reference/security/database/#auth
[3] https://github.com/urish/firebase-server/issues/88