### PR TITLE
Fix security rules validation for updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,6 +170,20 @@ FirebaseServer.prototype = {
 			return Promise.resolve(true);
 		}
 
+		function tryPatch(requestId, path, fbRef, newData) {
+			if (server._ruleset) {
+				return ruleSnapshot(fbRef).then(function (dataSnap) {
+					var result = server._ruleset.tryPatch(path, dataSnap, newData, authData());
+					if (!result.allowed) {
+						permissionDenied(requestId);
+						throw new Error('Permission denied for client to update at ' + path + ': ' + result.info);
+					}
+					return true;
+				});
+			}
+			return Promise.resolve(true);
+		}
+
 		function tryWrite(requestId, path, fbRef, newData) {
 			if (server._ruleset) {
 				return ruleSnapshot(fbRef).then(function (dataSnap) {
@@ -212,8 +226,8 @@ FirebaseServer.prototype = {
 
 			if (server._ruleset) {
 				checkPermission = exportData(fbRef).then(function (currentData) {
-					var mergedData = _.assign(currentData, newData);
-					return tryWrite(requestId, path, fbRef, mergedData);
+					var mergedData = _.assign(currentData || {}, newData);
+					return tryPatch(requestId, path, fbRef, mergedData);
 				});
 			}
 

--- a/test/server.spec.js
+++ b/test/server.spec.js
@@ -451,6 +451,46 @@ describe('Firebase Server', function () {
 			}));
 		});
 
+		it('should allow updates to children with different paths', function (done) {
+			var port = newFirebaseServer({
+				directories: {
+					alice: 'great!'
+				}
+			});
+			server.setRules({
+				rules: {
+					'.write': false,
+					users: {
+						'.write': true
+					},
+					directories: {
+						'.write': true
+					}
+				}
+			});
+
+			var client = newFirebaseClient(port);
+			client.update({
+				'users/bob': 'foo',
+				'directories/bob': 'bar',
+			}, co.wrap(function *(err) {
+				if (err) {
+					done(err);
+					return;
+				}
+				assert.deepEqual(yield server.getValue(), {
+					users: {
+						bob: 'foo'
+					},
+					directories: {
+						bob: 'bar',
+						alice: 'great!'
+					}
+				});
+				done();
+			}));
+		});
+
 		it('should use custom token to deny read', function (done) {
 			var port = newFirebaseServer({
 				user1: 'foo',


### PR DESCRIPTION
* updates can go into empty nodes: they will be created
  (thus `|| {}` shortcut)
* updates can be selective, so we have to use tryPatch instead of
  tryWrite

More on updates:
https://firebase.google.com/docs/database/web/read-and-write#update_specific_fields