### PR TITLE
Support passing a WebSocket.Server options object to the FirebaseServer constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ For more information, run:
 
 ### FirebaseServer methods
 
+The constructor signature is `FirebaseServer(portOrOptions, name, data)` where
+`portOrOptions` is either a port number or a
+[`WebSocket.Server`](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback)
+options object with either `port` or `server` set. `name` is optional and is
+just used to report the server name to clients. `data` is the initial contents
+of the database.
+
 FirebaseServer instances have the following API:
 
 * `close(callback)` - Stops the server (closes the server socket) and then calls the callback

--- a/README.md
+++ b/README.md
@@ -49,18 +49,18 @@ This package installs a CLI script called `firebase-server`. The following comma
 start a firebase server on port 5555:
 
 	node_modules/.bin/firebase-server -p 5555
-	
-To bootstrap the server with some data you can use the `-d,--data` or the `-f,--file` option. 
+
+To bootstrap the server with some data you can use the `-d,--data` or the `-f,--file` option.
 _Note: The file option will override the data option._
-	
+
 	node_modules/.bin/firebase-server -d '{"foo": "bar"}'
-	
+
 	node_modules/.bin/firebase-server -f ./path/to/data.json
-	
-To load [Firebase Security rules](https://firebase.google.com/docs/database/security/) upon startup you can use the `-r,--rules` option. 
-	
+
+To load [Firebase Security rules](https://firebase.google.com/docs/database/security/) upon startup you can use the `-r,--rules` option.
+
 	node_modules/.bin/firebase-server -r ./path/to/rules.json
-	
+
 For more information, run:
 
 	node_modules/.bin/firebase-server -h

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function normalizePath(fullPath) {
 	};
 }
 
-function FirebaseServer(port, name, data) {
+function FirebaseServer(portOrOptions, name, data) {
 	this.name = name || 'mock.firebase.server';
 
 	// Firebase is more than just a "database" now; the "realtime database" is
@@ -82,9 +82,23 @@ function FirebaseServer(port, name, data) {
 
 	this.baseRef.set(data || null);
 
-	this._wss = new WebSocketServer({
-		port: port
-	});
+	var port = portOrOptions;
+	if (typeof portOrOptions === 'object') {
+		this._wss = new WebSocketServer(portOrOptions);
+		if (portOrOptions.server) {
+			var address = portOrOptions.server.address();
+			if (address) {
+				port = address.port;
+			}
+		} else {
+			port = portOrOptions.port;
+		}
+	} else {
+		this._wss = new WebSocketServer({
+			port: portOrOptions
+		});
+		port = portOrOptions;
+	}
 
 	this._clock = new TestableClock();
 	this._tokenValidator = new TokenValidator(null, this._clock);

--- a/test/server.spec.js
+++ b/test/server.spec.js
@@ -10,6 +10,7 @@ var PORT = 45000;
 
 var originalWebsocket = require('faye-websocket');
 var assert = require('assert');
+var http = require('http');
 var proxyquire = require('proxyquire');
 var _ = require('lodash');
 
@@ -88,6 +89,22 @@ describe('Firebase Server', function () {
 		var app = firebase.initializeApp(config, name);
 		return app.database().ref();
 	}
+
+	it('should successfully use an existing http.Server', function (done) {
+		var httpServer = http.createServer();
+		httpServer.listen(sequentialPort);
+		var fbServer = new FirebaseServer({server: httpServer}, 'localhost:' + sequentialPort);
+		sequentialPort++;
+		fbServer.close(function () {
+			httpServer.close(done);
+		});
+	});
+
+	it('should successfully use port within options', function (done) {
+		var fbServer = new FirebaseServer({port: sequentialPort}, 'localhost:' + sequentialPort);
+		sequentialPort++;
+		fbServer.close(done);
+	});
 
 	it('should successfully accept a client connection', function (done) {
 		var port = newFirebaseServer();


### PR DESCRIPTION
This is useful to start a Firebase server on an existing http.Server, like the webpack dev server.