### PR TITLE
Align 'now' in Targaryen with firebase-server time

### DIFF
--- a/test/server.spec.js
+++ b/test/server.spec.js
@@ -574,6 +574,40 @@ describe('Firebase Server', () => {
 				}
 			});
 		});
+
+		it('should succeed in comparing ServerValue.TIMESTAMP to now', done => {
+			const port = newFirebaseServer({
+				Firebase: 'great!'
+			});
+			server.setRules({
+				rules: {
+					'timestamp': {
+						'.write': 'newData.val() === now'
+					},
+				},
+			});
+
+			const client = newFirebaseClient(port);
+			client.child('timestamp').set(
+				firebase.database.ServerValue.TIMESTAMP,
+				co.wrap(function *(err) {
+					if (err) {
+						done(err);
+						return;
+					}
+					assert((yield server.getValue()).timestamp);
+					client.update({
+						'timestamp': firebase.database.ServerValue.TIMESTAMP,
+					}, co.wrap(function *(err) {
+						if (err) {
+							done(err);
+							return;
+						}
+						assert((yield server.getValue()).timestamp);
+						done();
+					}));
+				}));
+		});
 	});
 
 	describe('#setPriority', () => {


### PR DESCRIPTION
This is achieved by passing the value of `now` to Targaryen validators. It will
also fix security rules which use `val() == now` expecting `val()` to be
ServerValue.TIMESTAMP. This is how production Firebase server works:
https://stackoverflow.com/questions/25433016/