### PR TITLE
Split send payloads according to firebase's custom continuation format

### DIFF
--- a/test/server.spec.ts
+++ b/test/server.spec.ts
@@ -223,6 +223,19 @@ describe('Firebase Server', () => {
 			});
 		});
 
+		it('should split long messages correctly according to the maxFrameLength parameter', async () => {
+			const options = { port: sequentialPort, maxFrameLength: 10 };
+			const server = new FirebaseServer(options, `localhost:${sequentialPort}`);
+			const client = newFirebaseClient(sequentialPort);
+			sequentialPort++;
+			await client.set({
+				foo: _.times(2000, String),
+			});
+			assert.deepEqual((await server.getValue()), {
+				foo: _.times(2000, String),
+			});
+		});
+
 		it('should support `firebase.database.ServerValue.TIMESTAMP` values', async () => {
 			const port = newFirebaseServer();
 			server.setTime(50001000102);


### PR DESCRIPTION
Hi Uri -

While using firebase-server we noticed that long messages being sent back from the web server were failing on the Java Firebase client. It turns out they have implemented a custom frame-chunking protocol as you can see here: https://github.com/firebase/firebase-admin-java/blob/d4a143801cf73e0de9641d29da9c5e72d1f91944/src/main/java/com/google/firebase/database/connection/WebsocketConnection.java#L124-L217.  This PR sends long messages in chunks and fixes our problem.

Thanks for a great tool!