### PR TITLE
Change declaration of FirebaseServer constructor data argument

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -71,7 +71,7 @@ class FirebaseServer {
 	private tokenValidator;
 	private maxFrameLength;
 
-	constructor(portOrOptions, private name = 'mock.firebase.server', data = null) {
+	constructor(portOrOptions, private name = 'mock.firebase.server', data?: {[key: string]: any}) {
 		// Firebase is more than just a "database" now; the "realtime database" is
 		// just one of many services provided by a Firebase "App" container.
 		// The Firebase library must be initialized with an App, and that app

--- a/index.ts
+++ b/index.ts
@@ -71,7 +71,7 @@ class FirebaseServer {
 	private tokenValidator;
 	private maxFrameLength;
 
-	constructor(portOrOptions, private name = 'mock.firebase.server', data?: {[key: string]: any}) {
+	constructor(portOrOptions, private name = 'mock.firebase.server', data: {[key: string]: any} | null = null) {
 		// Firebase is more than just a "database" now; the "realtime database" is
 		// just one of many services provided by a Firebase "App" container.
 		// The Firebase library must be initialized with an App, and that app


### PR DESCRIPTION
Currently, the FirebaseServer constructor is declared as:
``` typescript
constructor(portOrOptions, private name = 'mock.firebase.server', data = null)
```

The resulting `index.d.ts` file has the constructor as follows: `constructor(portOrOptions: any, name?: string, data?: null)` _(which is odd, and could be a tsc bug?)_
This means that `data` is optional and must be null, when used in a project that has strictNullChecks enabled.

I believe the type for the data argument should be:
``` typescript
constructor(portOrOptions, private name = 'mock.firebase.server', data: {[key: string]: any} | null = null)
```
Specifying an `data` argument which must be either `null` or an object containing keys and values (not a primitive), and defaults to `null`.


