### PR TITLE
respond with null instead of {} for empty path

### DIFF
--- a/lib/http-server.ts
+++ b/lib/http-server.ts
@@ -14,7 +14,7 @@ export function HttpServer(port: number, address: undefined, db: firebase.databa
 
 	function handleReadRequest(request: http.IncomingMessage, response: http.ServerResponse, path: string) {
 		db.ref(path).once('value').then((snapshot) => {
-			writeResponse(response, snapshot.val() || {});
+			writeResponse(response, snapshot.val());
 		});
 	}
 

--- a/test/http-server.spec.ts
+++ b/test/http-server.spec.ts
@@ -37,12 +37,12 @@ describe('Firebase HTTP Server', () => {
 	describe('get', () => {
 		context('root json', () => {
 			context('empty dataset', () => {
-				it('returns empty hash', () => {
+				it('returns null', () => {
 					const port = newFirebaseServer({});
 					return fetch(`http://localhost:${port}/.json`)
 						.then((resp) => resp.json())
 						.then((payload) => {
-							assert.deepEqual(payload, {});
+							assert.deepEqual(payload, null);
 						});
 				});
 			});


### PR DESCRIPTION
ref: #142 

Firebase returns `null` (not `{}`) when requesting an empty path.